### PR TITLE
Agregada petición API para panel de control

### DIFF
--- a/decide/store/serializers.py
+++ b/decide/store/serializers.py
@@ -10,3 +10,8 @@ class VoteSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Vote
         fields = ('voting_id', 'voter_id', 'a', 'b')
+
+class VotingSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Vote
+        fields = ('voting_id')

--- a/decide/store/urls.py
+++ b/decide/store/urls.py
@@ -1,7 +1,8 @@
-from django.urls import path, include
+from django.urls import path, include,re_path
 from . import views
 
 
 urlpatterns = [
     path('', views.StoreView.as_view(), name='store'),
+    re_path('^votings/(?P<voting_id>.+)/$', views.VotingView().as_view()),
 ]

--- a/decide/store/urls.py
+++ b/decide/store/urls.py
@@ -4,5 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.StoreView.as_view(), name='store'),
-    re_path('^votings/(?P<voting_id>.+)/$', views.VotingView().as_view()),
+    path('users/voting/<int:voting_id>/', views.VotingView().as_view(), name='store'),
 ]

--- a/decide/store/views.py
+++ b/decide/store/views.py
@@ -6,9 +6,23 @@ from rest_framework.response import Response
 from rest_framework import generics
 
 from .models import Vote
-from .serializers import VoteSerializer
+from .serializers import VoteSerializer,VotingSerializer
 from base import mods
 from base.perms import UserIsStaff
+from django.contrib.auth.models import User
+from django.http import JsonResponse
+
+class VotingView(generics.ListAPIView):
+    serializer_class = VotingSerializer
+    def get(self,request,voting_id):
+        voting_id = self.kwargs['voting_id']
+        result=Vote.objects.filter(voting_id=voting_id).values('voter_id')
+        #for id in result
+        #    result=User.objects.filter(id=id).values('username')
+        usernames = User.objects.filter(id__in=result).values('id','last_login','is_superuser','username','first_name','last_name',
+                                                              'email','is_staff','is_active','date_joined')
+        #return JsonResponse({"Vote": list(result)})
+        return JsonResponse({"User": list(usernames)})
 
 
 class StoreView(generics.ListAPIView):

--- a/decide/store/views.py
+++ b/decide/store/views.py
@@ -10,20 +10,19 @@ from .serializers import VoteSerializer,VotingSerializer
 from base import mods
 from base.perms import UserIsStaff
 from django.contrib.auth.models import User
-from django.http import JsonResponse
+
 
 class VotingView(generics.ListAPIView):
     serializer_class = VotingSerializer
     def get(self,request,voting_id):
+        self.permission_classes = (UserIsStaff,)
+        self.check_permissions(request)
         voting_id = self.kwargs['voting_id']
         result=Vote.objects.filter(voting_id=voting_id).values('voter_id')
-        #for id in result
-        #    result=User.objects.filter(id=id).values('username')
-        usernames = User.objects.filter(id__in=result).values('id','last_login','is_superuser','username','first_name','last_name',
-                                                              'email','is_staff','is_active','date_joined')
-        #return JsonResponse({"Vote": list(result)})
-        return JsonResponse({"User": list(usernames)})
-
+        usernames = User.objects.filter(id__in=result)\
+            .values('id','last_login','is_superuser','username','first_name','last_name',
+                        'email','is_staff','is_active','date_joined')
+        return Response(usernames,status=status.HTTP_200_OK)
 
 class StoreView(generics.ListAPIView):
     queryset = Vote.objects.all()
@@ -73,6 +72,7 @@ class StoreView(generics.ListAPIView):
             return Response({}, status=status.HTTP_401_UNAUTHORIZED)
 
         a = vote.get("a")
+
         b = vote.get("b")
 
         defs = { "a": a, "b": b }


### PR DESCRIPTION
**¿Que hace este pull request?**
Se han implementado los cambios necesarios para que la API de almacenamiento de votos,sea capaz de devolver los votantes de una votación pasada por parámetro.

[Link de la incidencia](https://github.com/danhidsan/decide-ganimedes-almacenamiento/issues/3)

**¿Por que estas haciendo el pull request?. Contexto del pull request.**
Esta funcionalidad se ha implementado con el fin de que sea usada en el desarrollo del panel de control y mediante una llamada a la API se sepa quién ha votado en la votación que se pasa por parámetro.

**¿Por dónde debe empezar el revisor?**
Deberá de crear al menos una votación y un par de usuarios que voten dicha votación.
Para probar la petición deberemos de obtener el id de la votación que hemos creado.
Una vez que tenemos el id iniciamos el servidor con:

`python manage.py runserver`

Una vez iniciado, deberemos de poner en el navegador la siguiente url, donde id_voting hace referencia al id de la votación que creamos anteriormente:

`http://localhost:8000/store/votings/**id_voting**/`

Dicha url nos deberá devolver un json en el que aparecerán los dos votantes que votaron en dicha votación. Algo como así, que nos muestran 3 usuarios que votaron en la votación que le pasamos por parámetro

{
"User": [
{
"id": 2,
"last_login": null,
"is_superuser": false,
"username": "julia",
"first_name": "",
"last_name": "",
"email": "",
"is_staff": false,
"is_active": true,
"date_joined": "2018-12-03T17:36:31.945Z"
},
{
"id": 3,
"last_login": null,
"is_superuser": false,
"username": "maria",
"first_name": "",
"last_name": "",
"email": "",
"is_staff": false,
"is_active": true,
"date_joined": "2018-12-03T17:36:46.067Z"
},
{
"id": 4,
"last_login": null,
"is_superuser": false,
"username": "pepe",
"first_name": "",
"last_name": "",
"email": "",
"is_staff": false,
"is_active": true,
"date_joined": "2018-12-03T17:41:16.735Z"
}